### PR TITLE
Port to Python3 - fix regressions

### DIFF
--- a/logcollect.py
+++ b/logcollect.py
@@ -459,15 +459,15 @@ class LogSend:
         response page.
         """
         content_type, body = self.encode_multipart_formdata(fields, files)
-        h = http.client.HTTP(host)
+        h = http.client.HTTPConnection(host)
         h.putrequest('POST', selector)
         h.putheader('content-type', content_type)
         h.putheader('content-length', str(len(body)))
         h.putheader('Host', host)
         h.endheaders()
         h.send(body)
-        errcode, errmsg, headers = h.getreply()
-        return h.file.read()
+        response = h.getresponse()
+        return response.read()
 
     def encode_multipart_formdata(self, fields, files):
         """


### PR DESCRIPTION
@quozl @pro-panda Can you help with how to test this change? I tried with command `python3 logcollect.py <server address>` given here https://github.com/sugarlabs/log-activity/blob/0c45118958be14a1844456703f0b392de250bc88/logcollect.py#L545 but that didn't work. Got in some unicode errors . Is it a right way to test?? 